### PR TITLE
Tiny tiny tiny tweak: GitHub OAuth scope separator is a comma

### DIFF
--- a/lib/passport-github/strategy.js
+++ b/lib/passport-github/strategy.js
@@ -20,6 +20,9 @@ var util = require('util')
  *   - `clientID`      your GitHub application's Client ID
  *   - `clientSecret`  your GitHub application's Client Secret
  *   - `callbackURL`   URL to which GitHub will redirect the user after granting authorization
+ *   - `scope`         array of permission scopes to request.  valid scopes include:
+ *                     'user', 'public_repo', 'repo', 'gist', or none.
+ *                     (see http://developer.github.com/v3/oauth/#scopes for more info)
  *
  * Examples:
  *
@@ -43,6 +46,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://github.com/login/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://github.com/login/oauth/access_token';
+  options.scopeSeparator = ',';
   
   OAuth2Strategy.call(this, options, verify);
   this.name = 'github';


### PR DESCRIPTION
Default scope separator to comma
Document "scope" parameter in the strategy a little.
