### PR TITLE
Add support for auth with Corporate GitHubs

### DIFF
--- a/lib/passport-github/strategy.js
+++ b/lib/passport-github/strategy.js
@@ -77,9 +77,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-//  this._oauth2.get('https://api.github.com/user', accessToken, function (err, body, res) {
   var url = this.userProfileURL;
-  //this._oauth2.get('https://github.paypal.com/api/v3/user', accessToken, function (err, body, res) {
   this._oauth2.get(url,  accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     


### PR DESCRIPTION
Minor changes needed to allow passport authorization with Corporate GitHubs plus the existing public GitHub already supported. Requires a new option (profileUrl) if you are using a corporate Github providing the URL for passport-github to use when doing the userProfile api call. For example, you might supply something like the following where corpDomain has the value for your corporate GitHub (e.g. github.mycorp.com)

"userProfileURL":"https://github.corpDomain/api/v3/user"

This is the only place that the api calling style differs for corporate  GitHub deployments for the things passport-github is doing.
