### PR TITLE
Add header "User-Agent" and retrieve verified email from github

### DIFF
--- a/lib/passport-github/strategy.js
+++ b/lib/passport-github/strategy.js
@@ -45,13 +45,12 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://github.com/login/oauth/authorize';
-  options.tokenURL = options.tokenURL || 'https://github.com/login/oauth/access_token';
+  options.authorizationURL = options.authorizationURL || "https://github.com/login/oauth/authorize";
+  options.tokenURL = options.tokenURL || "https://github.com/login/oauth/access_token";
   options.scopeSeparator = options.scopeSeparator || ',';
-  
   OAuth2Strategy.call(this, options, verify);
-  this.name = 'github';
-  this._userProfileURL = options.userProfileURL || 'https://api.github.com/user';
+  this.name = "github";
+  this._userProfileURL = options.userProfileURL || "https://api.github.com/user";
 }
 
 /**
@@ -77,26 +76,52 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
+  var self = this;
+  self._oauth2._request("GET", self._userProfileURL, {
+		"User-Agent": "cloudweaverdiscovery.com"
+    }, "", accessToken, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-    
     try {
-      var json = JSON.parse(body);
-      
-      var profile = { provider: 'github' };
-      profile.id = json.id;
-      profile.displayName = json.name;
-      profile.username = json.login;
-      profile.profileUrl = json.html_url;
-      profile.emails = [{ value: json.email }];
-      
-      profile._raw = body;
-      profile._json = json;
-      
-      done(null, profile);
-    } catch(e) {
-      done(e);
+        var json = JSON.parse(body);
+    } catch (e) {
+        done(e);
+        return;
     }
+    self._oauth2._request("GET", self._userProfileURL + "/emails", {
+		"Accept": "application/vnd.github.v3.full+json",
+		"User-Agent": "cloudweaverdiscovery.com"
+    }, "", accessToken, function (err, body, res) {
+        try {
+            var emails = JSON.parse(body);
+        } catch (e) {
+            done(e);
+            return;
+        }
+        var email, primaryEmail;
+        (emails || []).forEach(function (e) {
+        	if (e.verified) {
+        		email = e.email;
+        	}
+        	if (e.verified && e.primary) {
+        		primaryEmail = e.email;
+        	}
+        });
+        if (primaryEmail) {
+        	email = primaryEmail;
+        }
+        var profile = { provider: "github" };
+        profile.id = json.id;
+        profile.displayName = json.name;
+        profile.username = json.login;
+        profile.profileUrl = json.html_url;
+        profile.emails = [{ value: email }];
+
+        profile._raw = body;
+        profile._json = json;
+
+		done(null, profile);
+        
+    });
   });
 }
 


### PR DESCRIPTION
Github add requirement, that all requests should contain user-agent header. Also Github API returns Public email, which can be empty and not verified.

This pull request do the following:
— add User-Agent header
— Make one extra API call /user/emails to retrieve valid email
