### PR TITLE
Add User-Agent HTTP header, which required by Github API

### DIFF
--- a/lib/passport-github/strategy.js
+++ b/lib/passport-github/strategy.js
@@ -55,7 +55,7 @@ function Strategy(options, verify) {
   options.customHeaders = options.customHeaders || {};
   
   if (!options.customHeaders['User-Agent'] ) {
-    options.customHeaders['User-Agent'] = options.userAgent || 'user-agent';
+    options.customHeaders['User-Agent'] = options.userAgent || 'passport-github';
   }
   
   OAuth2Strategy.call(this, options, verify);


### PR DESCRIPTION
see http://developer.github.com/v3/#user-agent-required

New option added, userAgent, specifies value of User-Agent header.
By default passport-github
