### PR TITLE
Bump versions - vows 0.7, passport-oauth 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-github",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "GitHub authentication strategy for Passport.",
   "keywords": ["passport", "github", "auth", "authn", "authentication", "identity"],
   "repository": {
@@ -17,15 +17,15 @@
   },
   "licenses": [ {
     "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
+    "url": "http://www.opensource.org/licenses/MIT"
   } ],
   "main": "./lib/passport-github",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "~1.0.0"
   },
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "~0.7.x"
   },
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"


### PR DESCRIPTION
In preparation for some pull-requests related to this module and passport-oauth, I'm updating this module to passport-oauth 1.0.0.
