### PR TITLE
Fix Express-dependency

### DIFF
--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,7 +2,7 @@
   "name": "passport-github-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "^3.0.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-github": ">= 0.0.0"


### PR DESCRIPTION
>= 0.0.0 includes Express 4.x, which does not include any middleware at all. I fixed the package.json file in order to include the latest 3.x version. Otherwise the example would not work anymore (after reinstalling all dependencies).