### PR TITLE
Peg express version to 2.x to avoid error

### DIFF
--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,7 +2,7 @@
   "name": "passport-github-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "< 3.0.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-github": ">= 0.0.0"


### PR DESCRIPTION
the `.createServer()` method is deprecated in 3.x, this patch pegs the express version to 2.x to allow the example to run.