### PR TITLE
Handle no access token

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -88,6 +88,8 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
+  if (!accessToken) return done(new Error('No access token'));
+
   this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
     var json;
     

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -74,5 +74,26 @@ describe('Strategy#userProfile', function() {
       expect(profile).to.be.undefined;
     });
   });
+
+  describe('no access token', function() {
+    var err, profile;
+
+    before(function(done) {
+      strategy.userProfile(undefined, function(e, p) {
+        err = e;
+        profile = p;
+        done();
+      });
+    });
+
+    it('should error', function() {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.message).to.equal('No access token');
+    });
+
+    it('should not load profile', function() {
+      expect(profile).to.be.undefined;
+    });
+  });
   
 });


### PR DESCRIPTION
If given an incorrect `code` to swap for an `access_token` Github will return a 200 with an error in the body. `node-oauth` treats this as a success and proceeds to try to load the user profile. This will fail because there is no access token.

This PR prevents the request if there is no access token and gives the implementor a more relevant error.

I have a [PR open](https://github.com/ciaranj/node-oauth/pull/279) on `node-auth` that will provide a better fix but I thought this was nice to have anyway. 

The tests are passing and I added a couple of extra tests to cover the new functionality.