### PR TITLE
fix: accessToken should be in header for email lookup

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -135,7 +135,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
 
     if (self._scope && self._scope.indexOf('user:email') !== -1) {
-      self._oauth2._request('GET', self._userProfileURL + '/emails', { 'Accept': 'application/vnd.github.v3+json' }, '', accessToken, function(err, body, res) {
+      self._oauth2._request('GET', self._userProfileURL + '/emails', { 'Accept': 'application/vnd.github.v3+json', 'Authorization': `Bearer ${accessToken}` }, '', null, function(err, body, res) {
         if (err) {
           // If the attempt to fetch email addresses fails, return the profile
           // information that was obtained.


### PR DESCRIPTION
# Summary

It looks like github recently deprecated the `accessToken` as a request parameter for email lookup. Using version 1.1.0 of passport-github, it looks like we are simply catching the error when trying to get email and then returning the user. The error's root cause is:
```json
{
  "message":"Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param",
  "documentation_url":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"}'
}
```

The fix is to remove the `accessToken` from the query param of the request and add a new `Authorization` header with the bearer token.

It works after:
<img width="663" alt="Screenshot 2023-08-15 at 5 28 46 PM" src="https://github.com/jaredhanson/passport-github/assets/85070/74a5e0f0-acda-4109-b13f-f6797430135f">
